### PR TITLE
Update to Godot 4.0 anim_tree API

### DIFF
--- a/player/Player.tscn
+++ b/player/Player.tscn
@@ -58,10 +58,10 @@ xfade_time = 0.1
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_broob"]
 switch_mode = 2
-auto_advance = true
+advance_mode = 2
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_njbj0"]
-auto_advance = true
+advance_mode = 2
 
 [sub_resource type="AnimationNodeStateMachine" id="AnimationNodeStateMachine_d0nsn"]
 states/unarmed-jump/node = SubResource("AnimationNodeAnimation_xv5f5")
@@ -314,9 +314,12 @@ anim_player = NodePath("../CombatPack/AnimationPlayer")
 active = true
 parameters/Crouching/blend_position = 0
 parameters/Jump/active = false
+parameters/Jump/request = 0
 parameters/Jumping/playback = SubResource("AnimationNodeStateMachinePlayback_8horh")
 parameters/OnGround/blend_position = 0.0
-parameters/RootState/current = 0
+parameters/RootState/current_state = "on-ground"
+parameters/RootState/transition_request = ""
+parameters/RootState/current_index = 0
 parameters/Surging/blend_position = 0.0
 parameters/Swimming/blend_position = 0.0
 

--- a/player/states/Crouching.gd
+++ b/player/states/Crouching.gd
@@ -2,7 +2,7 @@ extends PlayerState
 
 func enter():
     # set the current animation root state to Crouching
-    player.anim_tree.set("parameters/RootState/current", 2)
+    player.anim_tree.set("parameters/RootState/transition_request", "crouching")
 
 func process(delta):
     # if the player is not trying to crouch, transition back to the OnGround state

--- a/player/states/InAir.gd
+++ b/player/states/InAir.gd
@@ -17,7 +17,7 @@ var _jump_cooldown_remaining: float = 0
 
 func enter():
     # set the current animation root state to Crouching
-    player.anim_tree.set("parameters/RootState/current", 1)
+    player.anim_tree.set("parameters/RootState/transition_request", "in-air")
 
 func process(delta):
     # count down the jump and dash cooldown timers
@@ -60,4 +60,4 @@ func accept_jump():
     # increase the jump count and reset the jump cooldown timer
     _jump_count += 1
     _jump_cooldown_remaining = jump_cooldown
-    player.anim_tree.set("parameters/Jump/active", 1)
+    player.anim_tree.set("parameters/Jump/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_FIRE)

--- a/player/states/OnGround.gd
+++ b/player/states/OnGround.gd
@@ -2,7 +2,7 @@ extends PlayerState
 
 func enter():
     # set the current animation root state to Crouching
-    player.anim_tree.set("parameters/RootState/current", 0)
+    player.anim_tree.set("parameters/RootState/transition_request", "on-ground")
 
 func process(delta):
     # if the jump button is pressed, transition into the InAir/Jumping state immediately

--- a/player/states/Swimming.gd
+++ b/player/states/Swimming.gd
@@ -2,4 +2,4 @@ extends PlayerState
 
 func enter():
     # set the current animation root state to Swimming
-    player.anim_tree.set("parameters/RootState/current", 3)
+    player.anim_tree.set("parameters/RootState/transition_request", "swimming")

--- a/player/states/Underwater.gd
+++ b/player/states/Underwater.gd
@@ -18,7 +18,7 @@ func process(delta):
     if player.controls.is_surging():
         # count towards the surge charge duration and navigate to the surging animation state
         _surge_charge_duration = min(surge_charge_duration, _surge_charge_duration + delta)
-        player.anim_tree.set("parameters/RootState/current", 4)
+        player.anim_tree.set("parameters/RootState/transition_request", "surging")
     elif _surge_charge_duration >= surge_charge_duration && _surge_cooldown_remaining <= 0:
         # otherwise if the player has sufficiently charged the surge, reset the surge cooldown and
         # charge duration timers, and also transition to the Swimming Surging state
@@ -28,7 +28,7 @@ func process(delta):
     else:
         # otherwise reset the surge charge duration and navigate to the swimming animation state
         _surge_charge_duration = 0
-        player.anim_tree.set("parameters/RootState/current", 3)
+        player.anim_tree.set("parameters/RootState/transition_request", "swimming")
 
 func exit():
     # reset the player skin's rotation in the X axis when exiting water


### PR DESCRIPTION
These are changes needed to make it work with 4.0 release version of engine.
1. In code, Transition `/current` renamed to `transition_request`
(I changed transitions indices to names, but in hindsight probably that's not needed).
2. In code, OneShot `active` changed to `/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_FIRE)`
3. In editor, states for Jump, changed in GUI from checkbox `autoadvance` to dropdown with Auto and had to be reapplied.
